### PR TITLE
Add Init parameter to docker run

### DIFF
--- a/docker/voice2json
+++ b/docker/voice2json
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 docker run -i \
+       --init \
        -v "${HOME}:${HOME}" \
+       -v "/dev/shm/:/dev/shm/" \
        -w "$(pwd)" \
        -e "HOME=${HOME}" \
        --user "$(id -u):$(id -g)" \
-       synesthesiam/voice2json:2.0.0 "$@"
+       synesthesiam/voice2json "$@"

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,7 +85,7 @@ $ sudo usermod -a -G docker $USER
 
 Create a Bash script named `voice2json` somewhere in your `$PATH` and add the following content:
 
-```
+```bash
 #!/usr/bin/env bash
 docker run -i \
        --init \

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,10 +85,12 @@ $ sudo usermod -a -G docker $USER
 
 Create a Bash script named `voice2json` somewhere in your `$PATH` and add the following content:
 
-```bash
+```
 #!/usr/bin/env bash
 docker run -i \
+       --init \
        -v "${HOME}:${HOME}" \
+       -v "/dev/shm/:/dev/shm/" \
        -w "$(pwd)" \
        -e "HOME=${HOME}" \
        --user "$(id -u):$(id -g)" \


### PR DESCRIPTION
This should fix the problem with wait wake not beeing able to be stopped when run in docker.
The init argument adds an init process to the container that forwards signals and reaps children on close.
This should effectively prevent any processes getting orphaned and beeing left behind as zombies.
Reference here:
https://docs.docker.com/config/containers/multi-service_container/
https://github.com/krallin/tini

I also added /dev/shm but you can take that out 😉 