### PR TITLE
Update install.md to add instructions for macOS

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -168,6 +168,12 @@ $ make install
 
 This will install `voice2json` inside a virtual environment at `$PWD/.venv` by default with **all** of the supported speech to text engines and supporting tools. When installation is finished, copy `voice2json.sh` somewhere in your `PATH` and rename it to `voice2json`.
 
+If you are building from source on macOS, you will also need to install [coreutils](https://www.gnu.org/software/coreutils/):
+
+```bash
+$ brew install coreutils
+```
+
 ### Customizing Installation
 
 You can pass additional information to `configure` to avoid installing parts of `voice2json` that you won't use. For example, if you only plan to use the French language profiles, set the `VOICE2JSON_LANGUAGE` environment variable to `fr` when configuring your installation:


### PR DESCRIPTION
Without `coreutils`, installation from source on macOS fails with error:
```
chmod +x "./voice2json/voice2json.sh"
install -D "./voice2json/voice2json.sh" "./voice2json/.venv/bin/voice2json"
install: illegal option -- D
usage: install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 file2
       install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 ... fileN directory
       install -d [-v] [-g group] [-m mode] [-o owner] directory ...
make: *** [install-voice2json] Error 64
```

After installing `coreutils` with Homebrew, I was able to install voice2json successfully on my macOS.

Reference: https://apple.stackexchange.com/a/201030