### PR TITLE
Update requirements.txt for python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
-aioconsole==0.1.16
-aiofiles==0.4.0
+aioconsole==0.2.0
+aiofiles==0.5.0
 aiohttp==3.7.4
 jsonlines==1.2.0
 networkx==2.4
 pydash==4.7.6
-pyyaml==5.4
+#pyyaml==5.4
+pyyaml!=6.0.0,!=5.4.0,!=5.4.1 # pyyaml is broken with cython 3
 rhasspy-asr-deepspeech~=0.4.0
 rhasspy-asr-kaldi~=0.6.0
 rhasspy-asr-pocketsphinx~=0.3.0
 rhasspy-nlu~=0.3.0
 rhasspy-silence~=0.4.0
 tqdm~=4.45.0
+legacy-cgi==2.6.2


### PR DESCRIPTION
work with arch linux (as of today, 9th of march 2025) and python 3.13